### PR TITLE
fix(types): specify versions, fix `MultisigAccount` type

### DIFF
--- a/custom_types.json
+++ b/custom_types.json
@@ -1,5 +1,5 @@
 {
-  "runtime_id": 19,
+  "runtime_id": 18,
   "versioning": [
     {
       "runtime_range": [
@@ -731,8 +731,17 @@
         "MultiCurrencyBalance": "Balance",
         "MultiCurrencyBalanceOf": "MultiCurrencyBalance",
         "MultisigAccount": {
-          "signatories": "Vec<AccountId>",
-          "threshold": "u8"
+          "type": "struct",
+          "type_mapping": [
+            [
+              "signatories",
+              "Vec<AccountId>"
+            ],
+            [
+              "threshold",
+              "u8"
+            ]
+          ]
         },
         "OffchainRequest": {
           "type": "enum",
@@ -1617,6 +1626,10 @@
     [
       1744716,
       9
+    ],
+    [
+      2829626,
+      19
     ]
   ]
 }


### PR DESCRIPTION
It turned out that `substrate-interface` requires to set inactual spec_version (`current_spec_version - 1`) to apply types from `versioning` — that's why we had `spec_version=8` instead of 9 [before](https://github.com/sora-xor/PythonBot/blob/d665a1580b683b8dbf4c68f50e112eb9ec30f8d0/custom_types.json#L2).
New `MultisigAccount` type was also specified incorrectly.
